### PR TITLE
clarify Added-Signed-Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,38 @@ note that content type and body hash are omitted for GET.
 
 #### POST Example
 
+https://example.acquiapipet.net/v1.0/task/
 
+non-auth headers:
+```
+Content-Type: application/json
+X-Acquia-Content-SHA256: 6paRNxUA7WawFxJpRp4cEixDjHq3jfIKX072k9slalo=
+```
+
+body:
+```
+{"method":"hi.bob","params":["5","4","8"]}
+```
+
+Authorization header =
+```
+Authorization: acquia-http-hmac realm="Pipet%20service",
+               id="efdde334-fe7b-11e4-a322-1697f925ec7b",
+               timestamp="1432075982.765341",
+               nonce="d1954337-5319-4821-8427-115542e08d10",
+               version="2.0",
+               signature="9tn9ZdUBc0BgXg2UdnUX7bi4oTUL9wakvzwBN16H+TI="
+```
+
+Signature-Base-String =
+```
+POST
+example.acquiapipet.net
+/v1.0/task
+id=efdde334-fe7b-11e4-a322-1697f925ec7b&nonce=d1954337-5319-4821-8427-115542e08d10&realm=Pipet%20service&timestamp=1432075982.782971&version=2.0
+application/json
+9tn9ZdUBc0BgXg2UdnUX7bi4oTUL9wakvzwBN16H+TI=
+```
 
 
 ## Further Reading

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ The signature base string is a concatenated string generated from the following 
 * `Authorization-Header-Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  The parameters are the id, nonce, realm, and version from the Authorization header. Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded (urlencoded)
 * `Added Signed Headers`: The normalized header names and values specified in the headers parameter of the Authorization header. Names should be lower-cased, sorted by name, separated from value by a colon and the value followed by a newline so each extra header is on its own line.
 * `Timestamp`:  The value of the X-Authorization-Timestamp header
-* `Content-Type`: The lowercase value of the "Content-type" header (or empty string if absent). Omit if Content-Length == 0.
-* `Body-Hash`: The base64 encoded SHA-256 digest of the raw body of the HTTP request, for POST, PUT, PATCH, DELETE or other requests that may have a body. Omit if Content-Length == 0. This should be identical to the string sent as the X-Authorization-Content-SHA256 header.
+* `Content-Type`: The lowercase value of the "Content-type" header (or empty string if absent). Omit if Content-Length is 0.
+* `Body-Hash`: The base64 encoded SHA-256 digest of the raw body of the HTTP request, for POST, PUT, PATCH, DELETE or other requests that may have a body. Omit if Content-Length is 0. This should be identical to the string sent as the X-Authorization-Content-SHA256 header.
 
 #### GET Example
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ authenticate API requests.
 
 ## Spec
 
-All requests must be made using HTTPS.
+Services implementing this spec must only accept requests using HTTPS.
 
 ## Overview of Header and Signature
 
@@ -41,6 +41,11 @@ Signature-Base-String =
 ```
 
 `"\n"` denotes a Unix-style line feed (ASCII code `0x0A`).
+
+#### Secret Key
+
+The secret key should be a 256 to 512 bit binary value. The secret key should be stored as a base64-encoded
+string representation and decoded to binary before use.
 
 #### Authorization Header
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Signature-Base-String =
     Authorization-Header-Parameters + "\n" +
     Added-Signed-Headers (if any) + "\n" +
     Timestamp +
-    (if Content-Length > 0)
+    (omit below if Content-Length is 0)
     "\n" + Content-Type +
     "\n" + Body-Hash
 ;

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Signature-Base-String =
     host  + "\n" +
     Path + "\n" +
     Query-Parameters + "\n" +
-    Header-Parameters + "\n" +
     Added-Signed-Headers (if any) + "\n" +
     Timestamp + (except for GET/HEAD) "\n" +
     Content-Type + "\n" +

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The signature base string is a concatenated string generated from the following 
 * `Added Signed Headers`: The normalized header names and values specified in the headers parameter of the Authorization header. Names should be lower-cased, sorted by name, separated from value by a colon and the value followed by a newline so each extra header is on its own line.
 * `Timestamp`:  The value of the X-Authorization-Timestamp header
 * `Content-Type`: The lowercase value of the "Content-type" header (or empty string if absent). Omit for a GET or HEAD request.
-* `Body-Hash`: SHA-256 digest of the raw body of the HTTP request, for POST, PUT, PATCH, DELETE or other requests that may have a body. Omit for GET or HEAD.
+* `Body-Hash`: The base64 encoded SHA-256 digest of the raw body of the HTTP request, for POST, PUT, PATCH, DELETE or other requests that may have a body. Omit for GET or HEAD. This should be identical to the string sent as the X-Authorization-Content-SHA256 header.
 
 #### GET Example
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Signature = Base64( HMAC( SecretKey, Signature-Base-String ) );
 
 Signature-Base-String =
     HTTP-Verb + "\n" +
+    Host + "\n" +
     Path + "\n" +
     Query-Parameters + "\n" +
     Authorization-Header-Parameters + "\n" +

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ following parts:
 The signature base string is a concatenated string generated from the following parts:
 
 * `HTTP-Verb`: The uppercase HTTP request method e.g. "GET", "POST"
-*  The (lowercase) hostname, matching the HTTP "Host" request header field (including any port number)
+* `Host`: The (lowercase) hostname, matching the HTTP "Host" request header field (including any port number)
 * `Path`: The HTTP request path with leading slash, e.g. `/resource/11`
 * `Parameters`: Any query parameters or empty string. This should be the exact string sent by the client, including urlencoding.
 * `Authorization-Header-Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  The parameters are the id, nonce, realm, and version from the Authorization header. Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded (urlencoded)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Signature-Base-String =
     host  + "\n" +
     Path + "\n" +
     Query-Parameters + "\n" +
+    Header-Parameters + "\n" +
     Added-Signed-Headers (if any) + "\n" +
     Timestamp + (except for GET/HEAD) "\n" +
     Content-Type + "\n" +

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The signature base string is a concatenated string generated from the following 
 
 https://example.acquiapipet.net/v1.0/task-status/133?limit=10
 
-Assuming the client ID is efdde334-fe7b-11e4-a322-1697f925ec7b and secret key is W5PeGMxSItNerkNFqQMfYiJvH14WzVJMy54CPoTAYoI=
+Assuming the client ID is efdde334-fe7b-11e4-a322-1697f925ec7b and bse64 encoded secret key is W5PeGMxSItNerkNFqQMfYiJvH14WzVJMy54CPoTAYoI=
 
 Authorization header =
 ```
@@ -102,7 +102,7 @@ Authorization: acquia-http-hmac realm="Pipet%20service",
                id="efdde334-fe7b-11e4-a322-1697f925ec7b",
                nonce="d1954337-5319-4821-8427-115542e08d10",
                version="2.0",
-               signature="noct7eQavSTgcE4vJRzUp4h6PM3i8JnwRadoB5LB5I8="
+               signature="MRlPr/Z1WQY2sMthcaEqETRMw4gPYXlPcTpaLWS2gcc="
 ```
 
 Other headers = 
@@ -144,7 +144,7 @@ Authorization: acquia-http-hmac realm="Pipet%20service",
                id="efdde334-fe7b-11e4-a322-1697f925ec7b",
                nonce="d1954337-5319-4821-8427-115542e08d10",
                version="2.0",
-               signature="nyRyqfHW08ePp5E0zFGFVCvrNxVRO8Ju+0BU6Zixw5Q="
+               signature="df5m8PBJj5porD3Tkg8nxcQnNMA5wj9H5btygdRnABE="
 ```
 
 Signature-Base-String =

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Note: 2.0 is not backwards compatible to 1.0 as the message to sign and the Head
 
 - [**Introduction**](#introduction)
 - [**Specification**](#spec)
-- [**Overview of Header and Signature**](#overview-header)
+- [**Overview of Header and Signature**](#overview-of-header-and-signature)
 - [**Response Validation**](#response-validation)
 - [**Security Considerations**](#security-considerations)
   - [MAC Keys Transmission](#mac-keys-transmission)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Signature-Base-String =
     "\n" + Content-Type +
     "\n" + Body-Hash
 ;
+```
 
 `"\n"` denotes a Unix-style line feed (ASCII code `0x0A`).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HTTP HMAC Spec
 
-This spec documents an HMAC message format for securing RESTful web APIs.
+This spec documents an HMAC authentication format for securing RESTful web APIs.
 
 [HMAC authentication](http://en.wikipedia.org/wiki/Hash-based_message_authentication_code)
 is a shared-secret cryptography method where signatures are generated on the
@@ -25,7 +25,7 @@ Authorization: acquia-http-hmac realm="Example",
                headers="",
                signature="Signature"
 
-X-Acquia-Timestamp: 1432075982
+X-Authorization-Timestamp: 1432075982
 
 Signature = Base64( HMAC( SecretKey, Signature-Base-String ) );
 
@@ -64,11 +64,11 @@ Each value should be enclosed in double quotes and urlencoded (percent encoded).
 
 Note that the name of this (standard) header is misleading - it carries authentication information.
 
-#### X-Acquia-Timestamp Header
+#### X-Authorization-Timestamp Header
 
 A Unix timestamp (integer seconds since Jan 1, 1970 UTC). Required for all requests. If this value differs by more than 900 seconds (15 minutes) from the time of the server, the request will be rejected.
 
-#### X-Acquia-Content-SHA256 Header
+#### X-Authorization-Content-SHA256 Header
 
 The base64 encoded SHA-256 hash value used to generate the signature base string. This is analogous to the standard Content-MD5 header. Required for any request except GET or HEAD.
 
@@ -86,12 +86,11 @@ following parts:
 The signature base string is a concatenated string generated from the following parts:
 
 * `HTTP-Verb`: The uppercase HTTP request method e.g. "GET", "POST"
-*  The (lowercase) hostname, matching the HTTP "Host" request header field
-* `Path`: The HTTP request path + query string, e.g. `/resource/11`
-* `Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  Any query parameters or empty string.  Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded (urlencoded).
-* `Header-Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  The parameters are the id, nonce, realm, and version from the Authorization header. Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded (urlencoded)
+*  The (lowercase) hostname, matching the HTTP "Host" request header field (including any port number)
+* `Path`: The HTTP request path with leading slash, e.g. `/resource/11`
+* `Parameters`: Any query parameters or empty string. This should be the exact string sent by the client, including urlencoding.
 * `Added Signed Headers`: The normalized header names and values specified in the headers parameter of the Authorization header. Names should be lower-cased, sorted by name, separated from value by a colon and the value followed by a newline so each extra header is on its own line.
-* `Timestamp`:  The value of the X-Acquia-Timestamp header
+* `Timestamp`:  The value of the X-Authorization-Timestamp header
 * `Content-Type`: The lowercase value of the "Content-type" header (or empty string if absent). Omit for a GET or HEAD request.
 * `Body-Hash`: SHA-256 digest of the raw body of the HTTP request, for POST, PUT, PATCH, DELETE or other requests that may have a body. Omit for GET or HEAD.
 
@@ -113,7 +112,7 @@ Authorization: acquia-http-hmac realm="Pipet%20service",
 
 Other headers = 
 ```
-X-Acquia-Timestamp: 1432075982
+X-Authorization-Timestamp: 1432075982
 ```
 
 Signature-Base-String =
@@ -134,9 +133,9 @@ https://example.acquiapipet.net/v1.0/task/
 
 Other headers:
 ```
-X-Acquia-Timestamp: 1432075982
+X-Authorization-Timestamp: 1432075982
 Content-Type: application/json
-X-Acquia-Content-SHA256: 6paRNxUA7WawFxJpRp4cEixDjHq3jfIKX072k9slalo=
+X-Authoization-Content-SHA256: 6paRNxUA7WawFxJpRp4cEixDjHq3jfIKX072k9slalo=
 ```
 
 body:
@@ -171,7 +170,7 @@ Except for HEAD requests, the reponse from the server must include the following
 
 Response header =
 ```
-X-Acquia-Content-HMAC-SHA256: UPiRBF/yd6po9Sv+1tBH5QmofBhQfm1R33okf4VyZtg=
+X-Server-Authorization-HMAC-SHA256: UPiRBF/yd6po9Sv+1tBH5QmofBhQfm1R33okf4VyZtg=
 ```
 
 The client should verify the reponse HMAC which authenticates the response body back from the server.
@@ -179,15 +178,17 @@ The client should verify the reponse HMAC which authenticates the response body 
 #### Response Signature Base String
 
 
-The signature base string is a concatenated string generated from the following parts:
+The response signature base string is a concatenated string generated from the following parts:
 
 * `Nonce`:  The nonce that was sent in the Authorization header.
+* `Timestamp`: The timestamp that was sent in the X-Authorization-Timestamp header
 * `Body`: The response body (or empty string).
 
 Signature-Base-String =
 
 ```
 d1954337-5319-4821-8427-115542e08d10
+1432075982
 {"id": 133, "status": "done"}
 ```
 
@@ -201,4 +202,4 @@ for frequently asked questions and a list of implementations in various language
 
 The algorithm is modeled after [Amazon Web Service's](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html)
 implementation and in part is derived from the HMAC authentication system
-developed for [Acquia Search](https://www.acquia.com/products-services/acquia-network/cloud-services/acquia-search) and [OAuth 1.0a](http://oauth.net/core/1.0a/) [RFC 5849](http://tools.ietf.org/html/rfc5849).
+developed for [Acquia Search](https://www.acquia.com/products-services/acquia-network/cloud-services/acquia-search). Elements of the spec were also informed by [OAuth 1.0a](http://oauth.net/core/1.0a/), [RFC 5849](http://tools.ietf.org/html/rfc5849), and [Hawk](https://github.com/hueniverse/hawk)

--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ The pseudocode below illustrates construction of the HTTP "Authorization" header
 Authorization: acquia-http-hmac realm="Example",
                id="identifier",
                timestamp="1432075982.782971",
+               nonce="d1954337-5319-4821-8427-115542e08d10",
                version=2.0,
                signature="Signature"
+
+X-Acquia-Content-SHA256:
 
 Signature = Base64( HMAC( SecretKey, Signature-Base-String ) );
 
@@ -50,6 +53,12 @@ The value of the `Authorization` header contains the following parts:
 * `version`: the version of this spec
 * `signature`: the Signature (base64 encoded) as described below.
 
+Each value should be enclosed in double quotes and urlencoded (percent encoded).
+
+#### X-Acquia-Content-SHA256 Header
+
+The SHA-256 hash value used to generate the signature base string. This is analogous to the standard Content-MD5 header.
+
 #### Signature
 
 The signature is a base64 encoded binary HMAC digest generated from the
@@ -68,8 +77,8 @@ The signature base string is a concatenated string generated from the following 
 * `Path`: The HTTP request path + query string, e.g. `/resource/11`
 * `Header-Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  The parameters are the realm, version, id, and timestamp from the Authorization header. Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded
 * `Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  Any GET query parameters.  Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded.
-* `Content-Type`: The lowercase value of the "Content-type" header, or empty string for a GET
-* `Body-Hash`: SHA-256 diget of the raw body of the HTTP request, for POST, PUT, PATH or other requests with a body, or an empty string for GET.
+* `Content-Type`: The lowercase value of the "Content-type" header, or omit for a GET or HEAD request.
+* `Body-Hash`: SHA-256 digest of the raw body of the HTTP request, for POST, PUT, PATH or other requests with a body, or an empty string for GET or HEAD.
 
 #### GET Example
 
@@ -83,7 +92,7 @@ Authorization: acquia-http-hmac realm="Pipet service",
                id="efdde334-fe7b-11e4-a322-1697f925ec7b",
                timestamp="1432075982.765341",
                nonce="d1954337-5319-4821-8427-115542e08d10",
-               version=2.0,
+               version="2.0",
                signature="9tn9ZdUBc0BgXg2UdnUX7bi4oTUL9wakvzwBN16H+TI="
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The signature base string is a concatenated string generated from the following 
 *  The (lowercase) hostname, matching the HTTP "Host" request header field (including any port number)
 * `Path`: The HTTP request path with leading slash, e.g. `/resource/11`
 * `Parameters`: Any query parameters or empty string. This should be the exact string sent by the client, including urlencoding.
+* `Header-Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  The parameters are the id, nonce, realm, and version from the Authorization header. Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded (urlencoded)
 * `Added Signed Headers`: The normalized header names and values specified in the headers parameter of the Authorization header. Names should be lower-cased, sorted by name, separated from value by a colon and the value followed by a newline so each extra header is on its own line.
 * `Timestamp`:  The value of the X-Authorization-Timestamp header
 * `Content-Type`: The lowercase value of the "Content-type" header (or empty string if absent). Omit for a GET or HEAD request.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The signature base string is a concatenated string generated from the following 
 
 https://example.acquiapipet.net/v1.0/task-status/133?limit=10
 
-Assuming the client ID is efdde334-fe7b-11e4-a322-1697f925ec7b and bse64 encoded secret key is W5PeGMxSItNerkNFqQMfYiJvH14WzVJMy54CPoTAYoI=
+Assuming the client ID is efdde334-fe7b-11e4-a322-1697f925ec7b and base64 encoded secret key is W5PeGMxSItNerkNFqQMfYiJvH14WzVJMy54CPoTAYoI=
 
 Authorization header =
 ```
@@ -157,6 +157,32 @@ id=efdde334-fe7b-11e4-a322-1697f925ec7b&nonce=d1954337-5319-4821-8427-115542e08d
 1432075982
 application/json
 9tn9ZdUBc0BgXg2UdnUX7bi4oTUL9wakvzwBN16H+TI=
+```
+
+## Response Validation
+
+The reponse from the server must include the following
+
+Response header =
+```
+X-Acquia-Content-HMAC-SHA256: UPiRBF/yd6po9Sv+1tBH5QmofBhQfm1R33okf4VyZtg=
+```
+
+The client should verify the reponse HMAC which authenticates the response body back from the server.
+
+#### Response Signature Base String
+
+
+The signature base string is a concatenated string generated from the following parts:
+
+* `Nonce`:  The nonce that was sent in the Authorization header.
+* `Body`: The response body (or empty string).
+
+Signature-Base-String =
+
+```
+d1954337-5319-4821-8427-115542e08d10
+{"id": 133, "status": "done"}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The value of the `Authorization` header contains the following parts:
 
 Each value should be enclosed in double quotes and urlencoded (percent encoded).
 
+Note that the name of this (standard) header is misleading - it carries authentication information.
+
 #### X-Acquia-Content-SHA256 Header
 
 The SHA-256 hash value used to generate the signature base string. This is analogous to the standard Content-MD5 header.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ The value of the `Authorization` header contains the following parts:
 
 * `realm`: The provider, for example "Acquia", "MyCompany", etc.
 * `id`: The API key's unique identifier, which is an arbitrary string
-* `timestamp`: A Unix timestamp (which may be treated by the server as a nonce) represented as a float with 6 digit (microtime) precision
+* `timestamp`: A Unix timestamp (which may be treated by the server as part of the nonce) represented as a float with 6 digit (microtime) precision
+* `nonce`:  a hex version 4 (or version 1) UUID.
 * `version`: the version of this spec
 * `signature`: the Signature (base64 encoded) as described below.
 
@@ -80,7 +81,8 @@ Authorization header =
 ```
 Authorization: acquia-http-hmac realm="Pipet service",
                id="efdde334-fe7b-11e4-a322-1697f925ec7b",
-               timestamp="1432075982.782971",
+               timestamp="1432075982.765341",
+               nonce="d1954337-5319-4821-8427-115542e08d10",
                version=2.0,
                signature="wBdTK16+htNDZNC4hnp3f+dnulBjTjBbss4OMHsmKw8="
 ```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Other headers:
 ```
 X-Authorization-Timestamp: 1432075982
 Content-Type: application/json
-X-Authoization-Content-SHA256: 6paRNxUA7WawFxJpRp4cEixDjHq3jfIKX072k9slalo=
+X-Authorization-Content-SHA256: 6paRNxUA7WawFxJpRp4cEixDjHq3jfIKX072k9slalo=
 ```
 
 body:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Signature-Base-String =
     Path + "\n" +
     Query-Parameters + "\n" +
     Authorization-Header-Parameters + "\n" +
-    Added-Signed-Headers (if any) + "\n" +
+    for each added signed header: added-signed-header-name:added-signed-header-value + "\n" +
     Timestamp +
     (omit below if Content-Length is 0)
     "\n" + Content-Type +
@@ -126,7 +126,7 @@ The signature base string is a concatenated string generated from the following 
 * `Path`: The HTTP request path with leading slash, e.g. `/resource/11`
 * `Parameters`: Any query parameters or empty string. This should be the exact string sent by the client, including urlencoding.
 * `Authorization-Header-Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  The parameters are the id, nonce, realm, and version from the Authorization header. Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded (urlencoded)
-* `Added Signed Headers`: The normalized header names and values specified in the headers parameter of the Authorization header. Names should be lower-cased, sorted by name, separated from value by a colon and the value followed by a newline so each extra header is on its own line.
+* `Added Signed Headers`: The normalized header names and values specified in the headers parameter of the Authorization header. Names should be lower-cased, sorted by name, separated from value by a colon and the value followed by a newline so each extra header is on its own line. If there are no added signed headers, an empty line should not be added to the signature base string.
 * `Timestamp`:  The value of the X-Authorization-Timestamp header
 * `Content-Type`: The lowercase value of the "Content-type" header (or empty string if absent). Omit if Content-Length is 0.
 * `Body-Hash`: The base64 encoded SHA-256 digest of the raw body of the HTTP request, for POST, PUT, PATCH, DELETE or other requests that may have a body. Omit if Content-Length is 0. This should be identical to the string sent as the X-Authorization-Content-SHA256 header.
@@ -277,7 +277,7 @@ cryptographically secure PRNGs to avoid these problems.
 
 The request MAC only covers the HTTP `Host` header, the `Content-Type` header and optionally a given set of Headers. It does not cover any other headers that it does not know about which can often affect how the request body is interpreted by the server. If the server behavior is influenced by the presence or value of such headers, an attacker can manipulate the request headers without being detected. Implementers should use the `headers` feature to pass headers to be added to the signature via the `Authorization` header which is protected by the request MAC. The Signature Base String will then be responsible of adding these given headers to the Signature so they become part of the MAC.
 
-The response authentication, when performed, only covers the response Body (payload) and some of the request information 
+The response authentication, when performed, only covers the response Body (payload) and some of the request information
 provided by the client in it's request such as timestamp and nonce. It does not cover the HTTP status code or
 any other response header field (e.g. Location) which can affect the client's behaviour.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Authorization: acquia-http-hmac realm="Pipet service",
                timestamp="1432075982.765341",
                nonce="d1954337-5319-4821-8427-115542e08d10",
                version=2.0,
-               signature="wBdTK16+htNDZNC4hnp3f+dnulBjTjBbss4OMHsmKw8="
+               signature="9tn9ZdUBc0BgXg2UdnUX7bi4oTUL9wakvzwBN16H+TI="
 ```
 
 Signature-Base-String =
@@ -92,7 +92,7 @@ Signature-Base-String =
 GET
 example.acquiapipet.net
 /v1.0/task-status/133
-id=efdde334-fe7b-11e4-a322-1697f925ec7b&realm=Pipet%20service&timestamp=1432075982.782971&version=2.0
+id=efdde334-fe7b-11e4-a322-1697f925ec7b&nonce=d1954337-5319-4821-8427-115542e08d10&realm=Pipet%20service&timestamp=1432075982.782971&version=2.0
 limit=10
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Assuming the client ID is efdde334-fe7b-11e4-a322-1697f925ec7b and secret key is
 
 Authorization header =
 ```
-Authorization: acquia-http-hmac realm="Pipet service",
+Authorization: acquia-http-hmac realm="Pipet%20service",
                id="efdde334-fe7b-11e4-a322-1697f925ec7b",
                timestamp="1432075982.765341",
                nonce="d1954337-5319-4821-8427-115542e08d10",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Note: This is inspired on the Hawk Spec and documentation.
+
 # HTTP HMAC Spec
 
 This spec documents an HMAC authentication format for securing RESTful web APIs.
@@ -276,12 +278,11 @@ any other response header field (e.g. Location) which can affect the client's be
 
 ### Future Time Manipulation
 
-The protocol relies on a clock sync between the client and server. To accomplish this, the server informs the client of its
-current time when an invalid timestamp is received. This happens in the form of a Date header in the response. See [RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18) as a motivation for this.
-
 If an attacker is able to manipulate this information and cause the client to use an incorrect time, it would be able to cause the client to generate authenticated requests using time in the future. Such requests will fail when sent by the client, and will not likely leave a trace on the server (given the common implementation of nonce, if at all enforced). The attacker will then be able to replay the request at the correct time without detection.
 
-The client must only use the time information provided by the server if:
+A solution to this problem would be a clock sync between the client and server. To accomplish this, the server informs the client of its current time when an invalid timestamp is received. This happens in the form of a Date header in the response. See [RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18) as a motivation for this.
+
+The client should only use the time information provided by the server if:
 * it was delivered over a TLS connection and the server identity has been verified, or
 * the MAC digest calculated using the same client credentials over the timestamp has been verified. (eg Response validation was successful)
 

--- a/README.md
+++ b/README.md
@@ -29,18 +29,19 @@ X-Authorization-Timestamp: 1432075982
 
 Signature = Base64( HMAC( SecretKey, Signature-Base-String ) );
 
+if Content-Length > 0
 Signature-Base-String =
     HTTP-Verb + "\n" +
-    host  + "\n" +
+    Host  + "\n" +
     Path + "\n" +
     Query-Parameters + "\n" +
     Authorization-Header-Parameters + "\n" +
     Added-Signed-Headers (if any) + "\n" +
-    Timestamp + (except for GET/HEAD) "\n" +
-    Content-Type + "\n" +
-    Body-Hash
+    Timestamp +
+    (if Content-Length > 0)
+    "\n" + Content-Type +
+    "\n" + Body-Hash
 ;
-```
 
 `"\n"` denotes a Unix-style line feed (ASCII code `0x0A`).
 
@@ -69,7 +70,7 @@ A Unix timestamp (integer seconds since Jan 1, 1970 UTC). Required for all reque
 
 #### X-Authorization-Content-SHA256 Header
 
-The base64 encoded SHA-256 hash value used to generate the signature base string. This is analogous to the standard Content-MD5 header. Required for any request except GET or HEAD.
+The base64 encoded SHA-256 hash value used to generate the signature base string. This is analogous to the standard Content-MD5 header. Required for any request where Content-Length > 0.
 
 #### Signature
 
@@ -91,8 +92,8 @@ The signature base string is a concatenated string generated from the following 
 * `Authorization-Header-Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  The parameters are the id, nonce, realm, and version from the Authorization header. Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded (urlencoded)
 * `Added Signed Headers`: The normalized header names and values specified in the headers parameter of the Authorization header. Names should be lower-cased, sorted by name, separated from value by a colon and the value followed by a newline so each extra header is on its own line.
 * `Timestamp`:  The value of the X-Authorization-Timestamp header
-* `Content-Type`: The lowercase value of the "Content-type" header (or empty string if absent). Omit for a GET or HEAD request.
-* `Body-Hash`: The base64 encoded SHA-256 digest of the raw body of the HTTP request, for POST, PUT, PATCH, DELETE or other requests that may have a body. Omit for GET or HEAD. This should be identical to the string sent as the X-Authorization-Content-SHA256 header.
+* `Content-Type`: The lowercase value of the "Content-type" header (or empty string if absent). Omit if Content-Length == 0.
+* `Body-Hash`: The base64 encoded SHA-256 digest of the raw body of the HTTP request, for POST, PUT, PATCH, DELETE or other requests that may have a body. Omit if Content-Length == 0. This should be identical to the string sent as the X-Authorization-Content-SHA256 header.
 
 #### GET Example
 
@@ -110,7 +111,7 @@ Authorization: acquia-http-hmac realm="Pipet%20service",
                signature="MRlPr/Z1WQY2sMthcaEqETRMw4gPYXlPcTpaLWS2gcc="
 ```
 
-Other headers = 
+Other headers =
 ```
 X-Authorization-Timestamp: 1432075982
 ```
@@ -135,7 +136,7 @@ Other headers:
 ```
 X-Authorization-Timestamp: 1432075982
 Content-Type: application/json
-X-Authorization-Content-SHA256: 6paRNxUA7WawFxJpRp4cEixDjHq3jfIKX072k9slalo=
+X-Authorization-Content-SHA256: 9tn9ZdUBc0BgXg2UdnUX7bi4oTUL9wakvzwBN16H+TI=
 ```
 
 body:
@@ -149,7 +150,7 @@ Authorization: acquia-http-hmac realm="Pipet%20service",
                id="efdde334-fe7b-11e4-a322-1697f925ec7b",
                nonce="d1954337-5319-4821-8427-115542e08d10",
                version="2.0",
-               signature="df5m8PBJj5porD3Tkg8nxcQnNMA5wj9H5btygdRnABE="
+               signature="XDBaXgWFCY3aAgQvXyGXMbw9Vds2WPKJe2yP+1eXQgM="
 ```
 
 Signature-Base-String =
@@ -170,7 +171,7 @@ Except for HEAD requests, the reponse from the server must include the following
 
 Response header =
 ```
-X-Server-Authorization-HMAC-SHA256: UPiRBF/yd6po9Sv+1tBH5QmofBhQfm1R33okf4VyZtg=
+X-Server-Authorization-HMAC-SHA256: M4wYp1MKvDpQtVOnN7LVt9L8or4pKyVLhfUFVJxHemU=
 ```
 
 The client should verify the reponse HMAC which authenticates the response body back from the server.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Note: 2.0 is not backwards compatible to 1.0 as the message to sign and the Head
 - [**Implementations**](#implementations)
 - [**Attribution**](#attribution)
 
+## Introduction
+TBD, see the Hawk spec for inspiration
 
 ## Spec
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Signature-Base-String =
     host  + "\n" +
     Path + "\n" +
     Query-Parameters + "\n" +
-    Header-Parameters + "\n" +
+    Authorization-Header-Parameters + "\n" +
     Added-Signed-Headers (if any) + "\n" +
     Timestamp + (except for GET/HEAD) "\n" +
     Content-Type + "\n" +
@@ -89,7 +89,7 @@ The signature base string is a concatenated string generated from the following 
 *  The (lowercase) hostname, matching the HTTP "Host" request header field (including any port number)
 * `Path`: The HTTP request path with leading slash, e.g. `/resource/11`
 * `Parameters`: Any query parameters or empty string. This should be the exact string sent by the client, including urlencoding.
-* `Header-Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  The parameters are the id, nonce, realm, and version from the Authorization header. Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded (urlencoded)
+* `Authorization-Header-Parameters`: normalized parameters similar to section 9.1.1 of OAuth 1.0a.  The parameters are the id, nonce, realm, and version from the Authorization header. Parameters are sorted by name and separated by '&' with name and value separated by =, percent encoded (urlencoded)
 * `Added Signed Headers`: The normalized header names and values specified in the headers parameter of the Authorization header. Names should be lower-cased, sorted by name, separated from value by a colon and the value followed by a newline so each extra header is on its own line.
 * `Timestamp`:  The value of the X-Authorization-Timestamp header
 * `Content-Type`: The lowercase value of the "Content-type" header (or empty string if absent). Omit for a GET or HEAD request.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ A Unix timestamp (integer seconds since Jan 1, 1970 UTC). Required for all reque
 
 The base64 encoded SHA-256 hash value used to generate the signature base string. This is analogous to the standard Content-MD5 header. Required for any request where Content-Length is not 0 (for example, a POST request with a body).
 
+#### X-Authenticated-Id Header
+
+If the X-Authenticated-Id is present in the request, the client implementing the validation of the request should reject the request and return "unauthenticated". This header is reserved for servers or proxies who want to validate requests and forward requests to backends. Backends can read this added header to understand if it was authenticated. Use this with caution and careful consideration as adding this header only guarantees it was authenticated to that ID.
+
 #### Signature
 
 The signature is a base64 encoded binary HMAC digest generated from the

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ X-Authorization-Timestamp: 1432075982
 
 Signature = Base64( HMAC( SecretKey, Signature-Base-String ) );
 
-if Content-Length > 0
 Signature-Base-String =
     HTTP-Verb + "\n" +
     Host  + "\n" +
@@ -70,7 +69,7 @@ A Unix timestamp (integer seconds since Jan 1, 1970 UTC). Required for all reque
 
 #### X-Authorization-Content-SHA256 Header
 
-The base64 encoded SHA-256 hash value used to generate the signature base string. This is analogous to the standard Content-MD5 header. Required for any request where Content-Length > 0.
+The base64 encoded SHA-256 hash value used to generate the signature base string. This is analogous to the standard Content-MD5 header. Required for any request where Content-Length is not 0 (for example, a POST request with a body).
 
 #### Signature
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,34 @@ is used by popular web services such as [AWS](http://docs.aws.amazon.com/AmazonS
 and in protocols such as [OAuth 1.0a](http://oauth.net/core/1.0a/) to sign and
 authenticate API requests.
 
+Current version: **2.0**
+
+Note: 2.0 is not backwards compatible to 1.0 as the message to sign and the Headers required are wildy different.
+
+# Table of Content
+
+- [**Introduction**](#introduction)
+- [**Specification**](#spec)
+- [**Overview of Header and Signature**](#overview-header)
+- [**Response Validation**](#response-validation)
+- [**Security Considerations**](#security-considerations)
+  - [MAC Keys Transmission](#mac-keys-transmission)
+  - [Confidentiality of Requests](#confidentiality-of-requests)
+  - [Spoofing by Counterfeit Servers](#spoofing-by-counterfeit-servers)
+  - [Plaintext Storage of Credentials](#plaintext-storage-of-credentials)
+  - [Entropy of Keys](#entropy-of-keys)
+  - [Coverage Limitations](#coverage-limitations)
+  - [Future Time Manipulation](#future-time-manipulation)
+  - [Client Clock Poisoning](#client-clock-poisoning)
+  - [Host Header Forgery](#host-header-forgery)
+<p></p>
+- [**Frequently Asked Questions**](#frequently-asked-questions)
+<p></p>
+- [**Further Reading**](#further-reading)
+- [**Implementations**](#implementations)
+- [**Attribution**](#attribution)
+
+
 ## Spec
 
 Production services implementing this spec must only accept requests using HTTPS.
@@ -192,11 +220,119 @@ d1954337-5319-4821-8427-115542e08d10
 {"id": 133, "status": "done"}
 ```
 
+## Security Considerations
+
+The greatest sources of security risks are usually found not in the Auth Protocol but in the policies and procedures surrounding its use.
+Implementers are strongly encouraged to assess how this module addresses their security requirements. This section includes
+an incomplete list of security considerations that must be reviewed and understood before deploying this Auth protocol on the server.
+Many of the protections provided in the specifications depends on whether and how they are used.
+
+### MAC Keys Transmission
+
+**Http Hmac Spec** does not provide any mechanism for obtaining or transmitting the set of shared credentials required. Any mechanism used to obtain **Http Hmac Spec** credentials must ensure that these transmissions are protected using transport-layer mechanisms such as TLS.
+
+### Confidentiality of Requests
+
+While **Http Hmac Spec**provides a mechanism for verifying the integrity of HTTP requests, it provides no guarantee of request confidentiality. Unless other precautions are taken, eavesdroppers will have full access to the request content. Servers should carefully consider the types of data likely to be sent as part of such requests, and employ transport-layer security mechanisms to protect sensitive resources.
+
+### Spoofing by Counterfeit Servers
+
+**Http Hmac Spec** provides limited verification of the server authenticity. When receiving a response back from the server, the server may choose to include a response `X-Server-Authorization-HMAC-SHA256` header which the client can use to verify the response. However, it is up to the server to determine when such measure is included, to up to the client to enforce that policy.
+
+A hostile party could take advantage of this by intercepting the client's requests and returning misleading or otherwise
+incorrect responses. Service providers should consider such attacks when developing services using this protocol, and should
+require transport-layer security for any requests where the authenticity of the resource server or of server responses is an issue.
+
+### Plaintext Storage of Credentials
+
+The **Http Hmac Spec** key functions the same way passwords do in traditional authentication systems. In order to compute the request MAC, the server must have access to the key in plaintext form. This is in contrast, for example, to modern operating systems, which store only a one-way hash of user credentials.
+
+If an attacker were to gain access to these keys - or worse, to the server's database of all such keys - he or she would be able to perform any action on behalf of any resource owner. Accordingly, it is critical that servers protect these keys from unauthorized access.
+
+### Entropy of Keys
+
+Unless a transport-layer security protocol is used, eavesdroppers will have full access to authenticated requests and request
+MAC values, and will thus be able to mount offline brute-force attacks to recover the key used. Servers should be careful to
+assign keys which are long enough, and random enough, to resist such attacks for at least the length of time that the **Http Hmac Spec** credentials are valid.
+
+For example, if the credentials are valid for two weeks, servers should ensure that it is not possible to mount a brute force
+attack that recovers the key in less than two weeks. Of course, servers are urged to err on the side of caution, and use the
+longest key reasonable.
+
+It is equally important that the pseudo-random number generator (PRNG) used to generate these keys be of sufficiently high
+quality. Many PRNG implementations generate number sequences that may appear to be random, but which nevertheless exhibit
+patterns or other weaknesses which make cryptanalysis or brute force attacks easier. Implementers should be careful to use
+cryptographically secure PRNGs to avoid these problems.
+
+### Coverage Limitations
+
+The request MAC only covers the HTTP `Host` header, the `Content-Type` header and optionally a given set of Headers. It does not cover any other headers that it does not know about which can often affect how the request body is interpreted by the server. If the server behavior is influenced by the presence or value of such headers, an attacker can manipulate the request headers without being detected. Implementers should use the `headers` feature to pass headers to be added to the signature via the `Authorization` header which is protected by the request MAC. The Signature Base String will then be responsible of adding these given headers to the Signature so they become part of the MAC.
+
+The response authentication, when performed, only covers the response Body (payload) and some of the request information 
+provided by the client in it's request such as timestamp and nonce. It does not cover the HTTP status code or
+any other response header field (e.g. Location) which can affect the client's behaviour.
+
+### Future Time Manipulation
+
+The protocol relies on a clock sync between the client and server. To accomplish this, the server informs the client of its
+current time when an invalid timestamp is received. This happens in the form of a Date header in the response. See [RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18) as a motivation for this.
+
+If an attacker is able to manipulate this information and cause the client to use an incorrect time, it would be able to cause the client to generate authenticated requests using time in the future. Such requests will fail when sent by the client, and will not likely leave a trace on the server (given the common implementation of nonce, if at all enforced). The attacker will then be able to replay the request at the correct time without detection.
+
+The client must only use the time information provided by the server if:
+* it was delivered over a TLS connection and the server identity has been verified, or
+* the MAC digest calculated using the same client credentials over the timestamp has been verified. (eg Response validation was successful)
+
+### Client Clock Poisoning
+
+When receiving a request with a bad timestamp, the server provides the client with its current time. The client must never use the time received from the server to adjust its own clock, and must only use it to calculate an offset for communicating with that particular server.
+
+### Host Header Forgery
+
+**Http Hmac Spec** validates the incoming request MAC against the incoming HTTP Host header. A malicous client can mint new host names pointing to the server's IP address and use that to craft an attack by sending a valid request that's meant for another hostname than the one used by the server. Server implementors must manually verify that the host header received matches their expectation. Eg, if you expect API calls on test.myapi.com, verify that that is the domain the request was sent to in the server implementation.
+
+## Frequently Asked Questions
+
+### Where is the protocol specification?
+
+If you are looking for some prose explaining how all this works, **this is it**. **Http Hmac Spec** is being developed as an open source project instead of a standard. In other words, this document is the specification. Not sure about something? Open an issue!
+
+### How is this different from [hawk](https://github.com/hueniverse/hawk)?
+* Allows to add a list of headers to be added to the signature.
+* Removes any support for bewit requests.
+
+### Is it done?
+
+No, it is still in development and we are trying to validate our assumptions every day.
+
+### Why not SHA1 or other algorithms to make the HMAC?
+
+SHA256 is a standard that is sufficient for message passing. It also doesn't require a lot of processing power to calculate the hash compared to more advanced protocols. We are confident that SHA256 is the best alternative we could choose and is also future proof. Therefor, we do not allow a custom algorithm in the request or in the protocol.
+
+### Why is request param normalization not needed? OAuth 2.0 requires it.
+Eran Hammer was so friendly to guide us to this answer. Request Parameters normalization was done for PHP4 support which did not provide access to the raw request URI or raw form encoded payload. Time has changed now and any language used should have direct access to the request params.
+
+### Why not just use HTTP Digest?
+
+Digest requires pre-negotiation to establish a nonce. This means you can't just make a request - you must first send
+a protocol handshake to the server. This pattern has become unacceptable for most web services, especially mobile
+where extra round-trip are costly.
+
+### Why bother with all this nonce and timestamp business?
+
+**Http Hmac Spec**, just like **Hawk** is an attempt to find a reasonable, practical compromise between security and usability. OAuth 1.0 got timestamp and nonces halfway right but failed when it came to scalability and consistent developer experience. **Http Hmac Spec** addresses it by requiring the client to sync its clock, but provides it with tools to accomplish it.
+
+In general, replay protection is a matter of application-specific threat model. It is less of an issue on a TLS-protected
+system where the clients are implemented using best practices and are under the control of the server. Instead of dropping
+replay protection, **Http Hmac Spec** offers a required time window and an optional nonce verification. Together, it provides developers with the ability to decide how to enforce their security policy without impacting the client's implementation.
 
 ## Further Reading
 
 Refer to the [wiki](https://github.com/acquia/http-hmac-spec/wiki)
 for frequently asked questions and a list of implementations in various languages.
+
+## Implementations
+List Auth Implementations here (go, php, bash, etc..)
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ Signature-Base-String =
 
 #### Secret Key
 
-The secret key should be a 256 to 512 bit binary value. The secret key should be stored as a base64-encoded
-string representation and decoded to binary before use.
+The secret key should be a 256 to 512 bit binary value. The secret key will normally be stored as a base64-encoded or hex-encoded string representation, but must be decoded to the binary value before use.
 
 #### Authorization Header
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Signature = Base64( HMAC( SecretKey, Signature-Base-String ) );
 
 Signature-Base-String =
     HTTP-Verb + "\n" +
-    Host  + "\n" +
     Path + "\n" +
     Query-Parameters + "\n" +
     Authorization-Header-Parameters + "\n" +


### PR DESCRIPTION
Clarified the fact that no empty line should be present if no added-signed-headers are being signed.
