### PR TITLE
PHP implementation supports v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,8 +427,6 @@ Some have v1 implementation as well.
 * [Java](https://github.com/acquia/http-hmac-java)
 * [Go](https://github.com/acquia/http-hmac-go)
 * [Ruby](https://github.com/acquia/http-hmac-ruby)
-
-### v1 Only
 * [PHP](https://github.com/acquia/http-hmac-php)
 
 ## Attribution


### PR DESCRIPTION
Link to PHP implementation was in the section "v1 only", but it supports version 2, so it should be moved to the right section.
